### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Download and install [Atom] for your platform
 
 [Atom]: https://atom.io/
 
-Run `apm install` from the root directory of this repository.
+Run `apm install`, followed by `apm link` from the root directory of this repository.
 
 Any file with a `.fst` extension will trigger loading of the language-fstar mode.
 For now, you only get very simple syntax highlighting.


### PR DESCRIPTION
...to [match the install.sh script](https://github.com/FStarLang/atom-fstar/blob/master/install.sh#L9).

Can't use install.sh in powershell... ;)
