### PR TITLE
An F* grammar fix to address unpaired quote (`) usage like those in reveal_opaque

### DIFF
--- a/grammars/fstar.cson
+++ b/grammars/fstar.cson
@@ -249,12 +249,24 @@ repository:
         ]
       }
       {
-        begin: '`'
+        begin: '`[^%]'
         beginCaptures:
           0: name: 'punctuation.definition.operator.begin.fstar'
         end: '`'
         endCaptures:
           0: name: 'punctuation.definition.operator.end.fstar'
+        name: 'string.quoted.template.fstar'
+        patterns: [
+          { include: '#op_names' }
+        ]
+      }
+      {
+        begin: '`%'
+        beginCaptures:
+          0: name: 'punctuation.definition.opaque_reveal_spec.begin.fstar'
+        end: '\s'
+        endCaptures:
+          0: name: 'punctuation.definition.opaque_reveal_spec.end.fstar'
         name: 'string.quoted.template.fstar'
         patterns: [
           { include: '#op_names' }

--- a/grammars/fstar.cson
+++ b/grammars/fstar.cson
@@ -263,7 +263,7 @@ repository:
       {
         begin: '`%'
         beginCaptures:
-          0: name: 'punctuation.definition.opaque_reveal_spec.begin.fstar'
+          0: name: 'punctuation.definition.opaque-reveal-spec.begin.fstar'
         end: '\\b'
         endCaptures:
           0: name: 'punctuation.definition.opaque_reveal_spec.end.fstar'

--- a/grammars/fstar.cson
+++ b/grammars/fstar.cson
@@ -264,7 +264,7 @@ repository:
         begin: '`%'
         beginCaptures:
           0: name: 'punctuation.definition.opaque_reveal_spec.begin.fstar'
-        end: '\s'
+        end: '\\b'
         endCaptures:
           0: name: 'punctuation.definition.opaque_reveal_spec.end.fstar'
         name: 'string.quoted.template.fstar'

--- a/grammars/fstar.cson
+++ b/grammars/fstar.cson
@@ -266,7 +266,7 @@ repository:
           0: name: 'punctuation.definition.opaque-reveal-spec.begin.fstar'
         end: '\\b'
         endCaptures:
-          0: name: 'punctuation.definition.opaque_reveal_spec.end.fstar'
+          0: name: 'punctuation.definition.opaque-reveal-spec.end.fstar'
         name: 'string.quoted.template.fstar'
         patterns: [
           { include: '#op_names' }

--- a/grammars/fstar.cson
+++ b/grammars/fstar.cson
@@ -25,7 +25,7 @@ repository:
         name: 'support.class.base.fstar'
       }
       {
-        match: '(/\\\\|\\\\/|<:|<@|[(][|]|[|][)]|u#|~>|->|<--|<-|<==>|==>|[?][.]|[.]\\[|[.]\\(|[{][:]pattern|::|:=|;;|[!][{]|\\[[|]|[|]>|[|]\\]|[~+^&?$|#,.:;=\\[\\](){}-])'
+        match: '(/\\\\|\\\\/|<:|<@|[(][|]|[|][)]|u#|`|~>|->|<--|<-|<==>|==>|[?][.]|[.]\\[|[.]\\(|[{][:]pattern|::|:=|;;|[!][{]|\\[[|]|[|]>|[|]\\]|[~+^&?$|#,.:;=\\[\\](){}-])'
         name: 'support.class.base.fstar'
       }
       {
@@ -246,30 +246,6 @@ repository:
             match: '.{2,}'
             name: 'invalid.illegal.string.js'
           }
-        ]
-      }
-      {
-        begin: '`[^%]'
-        beginCaptures:
-          0: name: 'punctuation.definition.operator.begin.fstar'
-        end: '`'
-        endCaptures:
-          0: name: 'punctuation.definition.operator.end.fstar'
-        name: 'string.quoted.template.fstar'
-        patterns: [
-          { include: '#op_names' }
-        ]
-      }
-      {
-        begin: '`%'
-        beginCaptures:
-          0: name: 'punctuation.definition.opaque-reveal-spec.begin.fstar'
-        end: '\\b'
-        endCaptures:
-          0: name: 'punctuation.definition.opaque-reveal-spec.end.fstar'
-        name: 'string.quoted.template.fstar'
-        patterns: [
-          { include: '#op_names' }
         ]
       }
     ]


### PR DESCRIPTION
This will fix F* highlighting (most importantly on github) in files with unpaired quotes ( ` ).

Problem code example:

```fstar
reveal_opaque (`%opaque_name) (opaque_name param);
reveal_opaque (`%opaque_name) (opaque_name param);
```